### PR TITLE
Simplify calculation of information matrix in vcov

### DIFF
--- a/R/vcov.btfit.R
+++ b/R/vcov.btfit.R
@@ -3,9 +3,8 @@ vcov_vec <- function(pi, N, ref = NULL) {
   object_names <- names(pi)
   wmat <- fitted_vec(pi, N)
   pmat <- btprob_vec(pi)
-  result <- wmat * Matrix::t(pmat)
-  diag(result) <- Matrix::rowSums(wmat * pmat) + Matrix::diag(wmat)
-  result <- diag(Matrix::rowSums(wmat)) - result
+  result <- - wmat * Matrix::t(pmat)
+  diag(result) <- - Matrix::rowSums(result)
 
   cmat <- stats::contr.sum(K, sparse = TRUE)
   result <- Matrix::chol2inv(Matrix::chol(Matrix::crossprod(cmat, result) %*% cmat))


### PR DESCRIPTION
Previously the code included a redundant diag(wmat) (which is zero) and had a slightly convoluted way of representing the observed Fisher information matrix.

The off-diagonal entries of J (`result`) are
`-w[ij] * p[ji]` (for `i != j`)
and the diagonal entries are simply
`sum_j { w[ij] * p[ji] }`,
for expected counts `W` and pairwise probabilities `P`.